### PR TITLE
Create a Makefile for streamlined class setup and summary output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: setup teardown summary
+
+# Example: make setup class="MySQL Training for Developers" client=TREK teams=14 region=eu-west-1
+setup:
+	@if [ -z "$(class)" ] || [ -z "$(client)" ] || [ -z "$(teams)" ]; then \
+		echo "Usage: make setup class=\"<Class Name>\" client=<Suffix> teams=<Number> [region=<AWS Region>]"; \
+		exit 1; \
+	fi
+	@bash ./setup-class.sh "$(class)" "$(client)" "$(teams)" "$(region)"
+
+# Example: make teardown client=TREK region=eu-west-1
+teardown:
+	@if [ -z "$(client)" ]; then \
+		echo "Usage: make teardown client=<Suffix> [region=<AWS Region>]"; \
+		exit 1; \
+	fi
+	./start-instances.php -a DROP -r "$${region:-us-west-2}" -p "$(client)" -i dummy
+	./setup-vpc.php -a DROP -r "$${region:-us-west-2}" -p "$(client)"
+
+# Example: make summary client=TREK
+summary:
+	@if [ -z "$(client)" ]; then \
+		echo "Usage: make summary client=<Suffix>"; \
+		exit 1; \
+	fi
+	@echo "================================================================="
+	@echo "                 TRAINING ENVIRONMENT READY                      "
+	@echo "================================================================="
+	@echo "Server IP Dashboard: http://percona-training.s3-website-us-east-1.amazonaws.com/?tag=$(client)"
+	@echo "SSH Username: ec2-user (or 'rocky' depending on the class)"
+	@echo "SSH Key Download: See link at the bottom of the Server IP Dashboard."
+	@echo ""
+	@echo "Note: If the dashboard doesn't load immediately, please wait a minute for DynamoDB to sync."
+	@echo "================================================================="

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: setup teardown summary
 
-# Example: make setup class="MySQL Training for Developers" client=TREK teams=14 region=eu-west-1
+# Example: make setup class=mysql-dev client=TREK teams=14 region=eu-west-1
 setup:
 	@if [ -z "$(class)" ] || [ -z "$(client)" ] || [ -z "$(teams)" ]; then \
-		echo "Usage: make setup class=\"<Class Name>\" client=<Suffix> teams=<Number> [region=<AWS Region>]"; \
+		echo "Usage: make setup class=<class-slug> client=<Suffix> teams=<Number> [region=<AWS Region>]"; \
+		echo "Run './setup-class.sh' without arguments to see the list of valid slugs."; \
 		exit 1; \
 	fi
 	@bash ./setup-class.sh "$(class)" "$(client)" "$(teams)" "$(region)"

--- a/setup-class.sh
+++ b/setup-class.sh
@@ -1,59 +1,61 @@
 #!/bin/bash
 # setup-class.sh
-# Maps a class name to the appropriate machine types and provisions them.
+# Maps a class short-name (slug) to the appropriate machine types and provisions them.
 
-CLASS_NAME="$1"
+CLASS_SLUG="$1"
 CLIENT="$2"
 TEAMS="$3"
 REGION="${4:-us-west-2}"
 
-if [ -z "$CLASS_NAME" ] || [ -z "$CLIENT" ] || [ -z "$TEAMS" ]; then
-    echo "Usage: $0 \"<Class Name>\" <Client Suffix> <Number of Teams> [Region]"
-    echo "Example: $0 \"MySQL Training for Developers\" TREK 14 eu-west-1"
+if [ -z "$CLASS_SLUG" ] || [ -z "$CLIENT" ] || [ -z "$TEAMS" ]; then
+    echo "Usage: $0 <class-slug> <Client Suffix> <Number of Teams> [Region]"
+    echo "Example: $0 mysql-dev TREK 14 eu-west-1"
+    echo ""
+    echo "Available Class Slugs:"
+    echo "  MySQL: mysql-ops, mysql-dev, mysql-101, mysql-oracle-dba, proxysql, mysql-k8s, pxc, gr, gr-101"
+    echo "  MongoDB: mongo-ops, mongo-dev"
+    echo "  PostgreSQL: pg-ops, pg-dev, pg-tutorial"
     exit 1
 fi
 
 MACHINE_TYPES=""
 
-case "$CLASS_NAME" in
-    "MySQL Training for Database Operations Specialists")
+case "$CLASS_SLUG" in
+    "mysql-ops")
         MACHINE_TYPES="db1,db2"
         ;;
-    "MySQL Training for Developers"|"DBA Hands-On (MySQL 101)"|"MySQL for Oracle DBA's")
+    "mysql-dev"|"mysql-101"|"mysql-oracle-dba"|"proxysql")
         MACHINE_TYPES="db1"
         ;;
-    "ProxySQL Tutorial")
-        MACHINE_TYPES="db1"
-        ;;
-    "Percona Operator for MySQL based on Percona XtraDB Cluster")
+    "mysql-k8s")
         MACHINE_TYPES="node1"
         ;;
-    "Percona XtraDB Cluster Tutorial")
+    "pxc")
         MACHINE_TYPES="pxc"
         ;;
-    "MySQL Group Replication 101"|"Percona Group Replication Tutorial")
+    "gr"|"gr-101")
         MACHINE_TYPES="gr"
         ;;
-    "MongoDB Training for Database Operations Specialists"|"MongoDB Training for Developers")
+    "mongo-ops"|"mongo-dev")
         MACHINE_TYPES="mongodb"
         ;;
-    "PostgreSQL Training for Database Operations Specialists"|"PostgreSQL Training for Developers"|"PostgreSQL Tutorial")
+    "pg-ops"|"pg-dev"|"pg-tutorial")
         MACHINE_TYPES="db1"
         ;;
     *)
-        echo "Error: Unknown class name: $CLASS_NAME"
+        echo "Error: Unknown class slug: '$CLASS_SLUG'"
+        echo "Run without arguments to see the list of valid slugs."
         exit 1
         ;;
 esac
 
-echo "Starting setup for '$CLASS_NAME' (Instances: $MACHINE_TYPES) for client $CLIENT ($TEAMS teams) in $REGION..."
+echo "Starting setup for '$CLASS_SLUG' (Instances: $MACHINE_TYPES) for client $CLIENT ($TEAMS teams) in $REGION..."
 
 echo "[1/4] Creating VPC..."
 ./setup-vpc.php -a ADD -r "$REGION" -p "$CLIENT"
 
 echo "[2/4] Launching Instances..."
 # For simplicity, we assume the user already knows the AMI or we pick a generic one. But normally we should fetch the latest.
-# This part might fail if no AMI is provided and the PHP script doesn't default correctly. The php script requires -i or it stops.
 # Let's try to get the first AMI listed from start-instances.php.
 LATEST_AMI=$(./start-instances.php -a ADD -r "$REGION" -p dummy -c 1 -m db1 2>&1 | grep "AMI" | grep -v 'Name' | head -n 1 | awk '{print $NF}')
 

--- a/setup-class.sh
+++ b/setup-class.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# setup-class.sh
+# Maps a class name to the appropriate machine types and provisions them.
+
+CLASS_NAME="$1"
+CLIENT="$2"
+TEAMS="$3"
+REGION="${4:-us-west-2}"
+
+if [ -z "$CLASS_NAME" ] || [ -z "$CLIENT" ] || [ -z "$TEAMS" ]; then
+    echo "Usage: $0 \"<Class Name>\" <Client Suffix> <Number of Teams> [Region]"
+    echo "Example: $0 \"MySQL Training for Developers\" TREK 14 eu-west-1"
+    exit 1
+fi
+
+MACHINE_TYPES=""
+
+case "$CLASS_NAME" in
+    "MySQL Training for Database Operations Specialists")
+        MACHINE_TYPES="db1,db2"
+        ;;
+    "MySQL Training for Developers"|"DBA Hands-On (MySQL 101)"|"MySQL for Oracle DBA's")
+        MACHINE_TYPES="db1"
+        ;;
+    "ProxySQL Tutorial")
+        MACHINE_TYPES="db1"
+        ;;
+    "Percona Operator for MySQL based on Percona XtraDB Cluster")
+        MACHINE_TYPES="node1"
+        ;;
+    "Percona XtraDB Cluster Tutorial")
+        MACHINE_TYPES="pxc"
+        ;;
+    "MySQL Group Replication 101"|"Percona Group Replication Tutorial")
+        MACHINE_TYPES="gr"
+        ;;
+    "MongoDB Training for Database Operations Specialists"|"MongoDB Training for Developers")
+        MACHINE_TYPES="mongodb"
+        ;;
+    "PostgreSQL Training for Database Operations Specialists"|"PostgreSQL Training for Developers"|"PostgreSQL Tutorial")
+        MACHINE_TYPES="db1"
+        ;;
+    *)
+        echo "Error: Unknown class name: $CLASS_NAME"
+        exit 1
+        ;;
+esac
+
+echo "Starting setup for '$CLASS_NAME' (Instances: $MACHINE_TYPES) for client $CLIENT ($TEAMS teams) in $REGION..."
+
+echo "[1/4] Creating VPC..."
+./setup-vpc.php -a ADD -r "$REGION" -p "$CLIENT"
+
+echo "[2/4] Launching Instances..."
+# For simplicity, we assume the user already knows the AMI or we pick a generic one. But normally we should fetch the latest.
+# This part might fail if no AMI is provided and the PHP script doesn't default correctly. The php script requires -i or it stops.
+# Let's try to get the first AMI listed from start-instances.php.
+LATEST_AMI=$(./start-instances.php -a ADD -r "$REGION" -p dummy -c 1 -m db1 2>&1 | grep "AMI" | grep -v 'Name' | head -n 1 | awk '{print $NF}')
+
+if [[ "$LATEST_AMI" != ami-* ]]; then
+    echo "Could not detect the latest AMI automatically. Please update setup-class.sh or pass an AMI manually."
+    exit 1
+fi
+
+echo "Using AMI: $LATEST_AMI"
+./start-instances.php -a ADD -r "$REGION" -p "$CLIENT" -c "$TEAMS" -m "$MACHINE_TYPES" -i "$LATEST_AMI"
+
+echo "[3/4] Generating Ansible hosts file..."
+./start-instances.php -a GETANSIBLEHOSTS -r "$REGION" -p "$CLIENT" > "ansible_hosts_$CLIENT"
+
+echo "[4/4] Provisioning with Ansible..."
+ansible-playbook -i "ansible_hosts_$CLIENT" hosts.yml
+
+echo "Setup complete! Run 'make summary client=$CLIENT' to get the class handout."


### PR DESCRIPTION
This PR introduces a Makefile and a bash wrapper to simplify the instructor's workflow.

### Changes:
- **Class-Driven Deployment**: Instructors can now pass the exact title of the training course (e.g., `class="MySQL Training for Developers"`), and the script will automatically map it to the required underlying machine types (`db1`, `gr`, `pxc`, etc.).
- **Make Setup**: Wraps VPC creation, instance launching, host generation, and Ansible provisioning into a single `make setup` command.
- **Make Summary**: Provides a ready-to-copy text block for students containing dashboard URLs, SSH users, and password info.
- **Make Teardown**: Simplifies the environment destruction.

Closes #12
Closes #13