### PR TITLE
Add 'make help' target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,41 @@
-.PHONY: setup teardown summary list-amis
+.PHONY: help setup teardown summary list-amis
+
+help:
+	@echo "================================================================="
+	@echo "              Percona Training AWS Infrastructure                "
+	@echo "================================================================="
+	@echo "Usage: make <target> [arguments]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  setup         Deploy a training environment"
+	@echo "                Args: class=<slug> client=<suffix> teams=<num> [region=<aws-region>]"
+	@echo "                Example: make setup class=mysql-dev client=TREK teams=14 region=eu-west-1"
+	@echo ""
+	@echo "  teardown      Destroy a training environment"
+	@echo "                Args: client=<suffix> [region=<aws-region>]"
+	@echo "                Example: make teardown client=TREK region=eu-west-1"
+	@echo ""
+	@echo "  summary       Show the dashboard URL and connection info"
+	@echo "                Args: client=<suffix>"
+	@echo "                Example: make summary client=TREK"
+	@echo ""
+	@echo "  list-amis     List available Percona Training AMIs"
+	@echo "                Args: [region=<aws-region>]"
+	@echo "                Example: make list-amis region=eu-west-1"
+	@echo ""
+	@echo "  help          Show this help message"
+	@echo "================================================================="
+	@echo ""
+	@echo "Rich Examples:"
+	@echo "  # Deploy a 10-team MongoDB class in US-East-1:"
+	@echo "  make setup class=mongodb-admin client=NYC teams=10 region=us-east-1"
+	@echo ""
+	@echo "  # Clean up the TREK environment in the default region (us-west-2):"
+	@echo "  make teardown client=TREK"
+	@echo ""
+	@echo "  # Quickly check which AMIs are available in London:"
+	@echo "  make list-amis region=eu-west-2"
+	@echo "================================================================="
 
 # Example: make list-amis region=eu-west-1
 list-amis:


### PR DESCRIPTION
This PR adds a default 'help' target to the Makefile, including several examples for setup, teardown, and AMI listing. This helps users quickly discover available commands and their correct usage.