### PR TITLE
Enhance CLI to suggest active slugs and regions on parameter errors

### DIFF
--- a/src/Command/AnsibleConfigCommand.php
+++ b/src/Command/AnsibleConfigCommand.php
@@ -27,11 +27,11 @@ class AnsibleConfigCommand extends BaseCommand
 	{
 		$parser->addArguments([
 			'slug' => [
-				'required' => true,
+				'required' => false,
 				'help' => 'The slug/suffix for the class',
 			],
 			'region' => [
-				'required' => true,
+				'required' => false,
 				'help' => 'The region to list from',
 			],
 		]);
@@ -53,8 +53,15 @@ class AnsibleConfigCommand extends BaseCommand
 	public function execute(Arguments $args, ConsoleIo $io): ?int
 	{
 		// Get arguments
-		$slug   = $args->getArgument('slug') ?: $io->abort('Missing slug parameter');
-		$region = $args->getArgument('region') ?: $io->abort('Missing region parameter');
+		$slug   = $args->getArgument('slug');
+		$region = $args->getArgument('region');
+
+		if (!$slug || !$region)
+		{
+			$this->missingArgsError($io);
+
+			return static::CODE_ERROR;
+		}
 
 		try
 		{
@@ -202,5 +209,44 @@ class AnsibleConfigCommand extends BaseCommand
 		}
 
 		return static::CODE_SUCCESS;
+	}
+
+	/**
+	 * Outputs a helpful error message when required arguments are missing.
+	 */
+	private function missingArgsError(ConsoleIo $io): void
+	{
+		$discovered = Learnomancer\LearnomancerConfig::discoverActiveConfig();
+
+		if (!empty($discovered['slugs']))
+		{
+			$io->out('Discovered active slugs in your workspace: ' . implode(', ', $discovered['slugs']));
+		}
+		else
+		{
+			$io->out('No active class configurations discovered in your workspace.');
+		}
+
+		if (!empty($discovered['regions']))
+		{
+			$io->out('Discovered active regions in your workspace: ' . implode(', ', $discovered['regions']));
+		}
+		else
+		{
+			$io->out('Standard AWS regions: us-east-1, us-west-1, us-west-2, eu-west-1, etc.');
+		}
+
+		if (!empty($discovered['slugs']) && !empty($discovered['regions']))
+		{
+			$sampleSlug   = $discovered['slugs'][0];
+			$sampleRegion = $discovered['regions'][0];
+			$io->out("\nSuggested command to run:");
+			$io->out("  bin/learnomancer ansible-config {$sampleSlug} {$sampleRegion}");
+		}
+		else
+		{
+			$io->out("\nExample command to run:");
+			$io->out('  bin/learnomancer ansible-config ACME us-west-1');
+		}
 	}
 }

--- a/src/Command/ListAmisCommand.php
+++ b/src/Command/ListAmisCommand.php
@@ -27,7 +27,7 @@ class ListAmisCommand extends BaseCommand
 	{
 		$parser->addArguments([
 			'region' => [
-				'required' => true,
+				'required' => false,
 				'help' => 'The region to list from',
 			],
 		]);
@@ -43,7 +43,37 @@ class ListAmisCommand extends BaseCommand
 	public function execute(Arguments $args, ConsoleIo $io): ?int
 	{
 		// Get arguments
-		$region = $args->getArgument('region') ?: $io->abort('Missing region parameter');
+		$region = $args->getArgument('region');
+
+		if (!$region)
+		{
+			$discovered = Learnomancer\LearnomancerConfig::discoverActiveConfig();
+			$io->err('<error>Error: Missing required argument.</error>');
+			$io->err("Usage: learnomancer list-amis <region>\n");
+
+			if (!empty($discovered['regions']))
+			{
+				$io->out('Discovered active regions in your workspace: ' . implode(', ', $discovered['regions']));
+			}
+			else
+			{
+				$io->out('Standard AWS regions: us-east-1, us-west-1, us-west-2, eu-west-1, etc.');
+			}
+
+			if (!empty($discovered['regions']))
+			{
+				$sampleRegion = $discovered['regions'][0];
+				$io->out("\nSuggested command to run:");
+				$io->out("  bin/learnomancer list-amis {$sampleRegion}");
+			}
+			else
+			{
+				$io->out("\nExample command to run:");
+				$io->out('  bin/learnomancer list-amis us-west-1');
+			}
+
+			return static::CODE_ERROR;
+		}
 
 		/** @var \Learnomancer\Command\Helper\TableHelper $tableHelper */
 		$tableHelper = $io->helper('Learnomancer\Command\Helper\TableHelper');

--- a/src/Command/ListInstancesCommand.php
+++ b/src/Command/ListInstancesCommand.php
@@ -27,11 +27,11 @@ class ListInstancesCommand extends BaseCommand
 	{
 		$parser->addArguments([
 			'slug' => [
-				'required' => true,
+				'required' => false,
 				'help' => 'The slug/suffix for the class',
 			],
 			'region' => [
-				'required' => true,
+				'required' => false,
 				'help' => 'The region to list from',
 			],
 		]);
@@ -47,8 +47,48 @@ class ListInstancesCommand extends BaseCommand
 	public function execute(Arguments $args, ConsoleIo $io): ?int
 	{
 		// Get arguments
-		$slug   = $args->getArgument('slug') ?: $io->abort('Missing slug parameter');
-		$region = $args->getArgument('region') ?: $io->abort('Missing region parameter');
+		$slug   = $args->getArgument('slug');
+		$region = $args->getArgument('region');
+
+		if (!$slug || !$region)
+		{
+			$discovered = Learnomancer\LearnomancerConfig::discoverActiveConfig();
+			$io->err('<error>Error: Missing required argument(s).</error>');
+			$io->err("Usage: learnomancer list-instances <slug> <region>\n");
+
+			if (!empty($discovered['slugs']))
+			{
+				$io->out('Discovered active slugs in your workspace: ' . implode(', ', $discovered['slugs']));
+			}
+			else
+			{
+				$io->out('No active class configurations discovered in your workspace.');
+			}
+
+			if (!empty($discovered['regions']))
+			{
+				$io->out('Discovered active regions in your workspace: ' . implode(', ', $discovered['regions']));
+			}
+			else
+			{
+				$io->out('Standard AWS regions: us-east-1, us-west-1, us-west-2, eu-west-1, etc.');
+			}
+
+			if (!empty($discovered['slugs']) && !empty($discovered['regions']))
+			{
+				$sampleSlug   = $discovered['slugs'][0];
+				$sampleRegion = $discovered['regions'][0];
+				$io->out("\nSuggested command to run:");
+				$io->out("  bin/learnomancer list-instances {$sampleSlug} {$sampleRegion}");
+			}
+			else
+			{
+				$io->out("\nExample command to run:");
+				$io->out('  bin/learnomancer list-instances ACME us-west-1');
+			}
+
+			return static::CODE_ERROR;
+		}
 
 		/** @var \Learnomancer\Command\Helper\TableHelper $tableHelper */
 		$tableHelper = $io->helper('Learnomancer\Command\Helper\TableHelper');

--- a/src/Command/ListVpcsCommand.php
+++ b/src/Command/ListVpcsCommand.php
@@ -27,7 +27,7 @@ class ListVpcsCommand extends BaseCommand
 	{
 		$parser->addArguments([
 			'region' => [
-				'required' => true,
+				'required' => false,
 				'help' => 'The region to list from',
 			],
 		]);
@@ -43,7 +43,37 @@ class ListVpcsCommand extends BaseCommand
 	public function execute(Arguments $args, ConsoleIo $io): ?int
 	{
 		// Get arguments
-		$region = $args->getArgument('region') ?: $io->abort('Missing region parameter');
+		$region = $args->getArgument('region');
+
+		if (!$region)
+		{
+			$discovered = Learnomancer\LearnomancerConfig::discoverActiveConfig();
+			$io->err('<error>Error: Missing required argument.</error>');
+			$io->err("Usage: learnomancer list-vpcs <region>\n");
+
+			if (!empty($discovered['regions']))
+			{
+				$io->out('Discovered active regions in your workspace: ' . implode(', ', $discovered['regions']));
+			}
+			else
+			{
+				$io->out('Standard AWS regions: us-east-1, us-west-1, us-west-2, eu-west-1, etc.');
+			}
+
+			if (!empty($discovered['regions']))
+			{
+				$sampleRegion = $discovered['regions'][0];
+				$io->out("\nSuggested command to run:");
+				$io->out("  bin/learnomancer list-vpcs {$sampleRegion}");
+			}
+			else
+			{
+				$io->out("\nExample command to run:");
+				$io->out('  bin/learnomancer list-vpcs us-west-1');
+			}
+
+			return static::CODE_ERROR;
+		}
 
 		/** @var \Learnomancer\Command\Helper\TableHelper $tableHelper */
 		$tableHelper = $io->helper('Learnomancer\Command\Helper\TableHelper');

--- a/src/Command/SshConfigCommand.php
+++ b/src/Command/SshConfigCommand.php
@@ -32,11 +32,11 @@ class SshConfigCommand extends BaseCommand
 
 		$parser->addArguments([
 			'slug' => [
-				'required' => true,
+				'required' => false,
 				'help' => 'The slug/suffix for the class',
 			],
 			'region' => [
-				'required' => true,
+				'required' => false,
 				'help' => 'The region to list from',
 			],
 		]);
@@ -58,8 +58,48 @@ class SshConfigCommand extends BaseCommand
 	public function execute(Arguments $args, ConsoleIo $io): ?int
 	{
 		// Get arguments
-		$slug   = $args->getArgument('slug') ?: $io->abort('Missing slug parameter');
-		$region = $args->getArgument('region') ?: $io->abort('Missing region parameter');
+		$slug   = $args->getArgument('slug');
+		$region = $args->getArgument('region');
+
+		if (!$slug || !$region)
+		{
+			$discovered = Learnomancer\LearnomancerConfig::discoverActiveConfig();
+			$io->err('<error>Error: Missing required argument(s).</error>');
+			$io->err("Usage: learnomancer ssh-config <slug> <region> [--output]\n");
+
+			if (!empty($discovered['slugs']))
+			{
+				$io->out('Discovered active slugs in your workspace: ' . implode(', ', $discovered['slugs']));
+			}
+			else
+			{
+				$io->out('No active class configurations discovered in your workspace.');
+			}
+
+			if (!empty($discovered['regions']))
+			{
+				$io->out('Discovered active regions in your workspace: ' . implode(', ', $discovered['regions']));
+			}
+			else
+			{
+				$io->out('Standard AWS regions: us-east-1, us-west-1, us-west-2, eu-west-1, etc.');
+			}
+
+			if (!empty($discovered['slugs']) && !empty($discovered['regions']))
+			{
+				$sampleSlug   = $discovered['slugs'][0];
+				$sampleRegion = $discovered['regions'][0];
+				$io->out("\nSuggested command to run:");
+				$io->out("  bin/learnomancer ssh-config {$sampleSlug} {$sampleRegion}");
+			}
+			else
+			{
+				$io->out("\nExample command to run:");
+				$io->out('  bin/learnomancer ssh-config ACME us-west-1');
+			}
+
+			return static::CODE_ERROR;
+		}
 
 		try
 		{

--- a/src/LearnomancerConfig.php
+++ b/src/LearnomancerConfig.php
@@ -106,4 +106,38 @@ final class LearnomancerConfig
 			$this->$property = $value;
 		}
 	}
+
+	/**
+	 * Scans the root directory for any local configuration files
+	 * and returns an array of unique discovered slugs and regions.
+	 *
+	 * @return array{slugs: array<int, string>, regions: array<int, string>}
+	 */
+	public static function discoverActiveConfig(): array
+	{
+		$slugs   = [];
+		$regions = [];
+
+		$files = glob(dirname(__DIR__) . '/.config-percona-training-*.cnf');
+		if ($files === false)
+		{
+			$files = [];
+		}
+
+		foreach ($files as $file)
+		{
+			$filename = basename($file);
+			// Match: .config-percona-training-{slug}-{region}.cnf
+			if (preg_match('/^\.config-percona-training-([^-]+)-(.+)\.cnf$/i', $filename, $matches))
+			{
+				$slugs[]   = strtoupper($matches[1]);
+				$regions[] = strtolower($matches[2]);
+			}
+		}
+
+		return [
+			'slugs' => array_values(array_unique($slugs)),
+			'regions' => array_values(array_unique($regions)),
+		];
+	}
 }


### PR DESCRIPTION
This PR addresses #30 by implementing local class configuration auto-discovery inside LearnomancerConfig. It modifies ListInstancesCommand, ListVpcsCommand, ListAmisCommand, SshConfigCommand, and AnsibleConfigCommand to make arguments optional, providing rich suggestion outputs listing all active slugs/regions and a working example command when required parameters are omitted.